### PR TITLE
fix(deps::babel/code-frame): Upgrade codeframe

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/bencergazda/stylelint-codeframe-formatter#readme",
   "dependencies": {
-    "@babel/code-frame": "^7.14.5",
+    "@babel/code-frame": "^7.16.7",
     "chalk": "^2.4.2",
     "log-symbols": "^2.2.0",
     "plur": "^2.1.2"


### PR DESCRIPTION
Hello, we've found that the current codeframe version in this package has some issues in empty files.
> 👉 See babel PR：https://github.com/babel/babel/pull/14165

The babel highlighter used in `@babel/code-frame` package would trapped in an `infinite loop`.Therefore, we're hoping to upgrade the deps to that version `v7.16.7` in order to solve that problem.

@bencergazda Please help to see if this would possible, thanks! ❤