### PR TITLE
docs: simplify usage of `--custom-formatter` on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ npm install stylelint-codeframe-formatter --save-dev
 ### Stylelint CLI
 
 ```
-$ stylelint --custom-formatter node_modules/stylelint-codeframe-formatter file.css
+$ stylelint --custom-formatter stylelint-codeframe-formatter file.css
 ```
 
 ### [stylelint-webpack-plugin](https://github.com/JaKXz/stylelint-webpack-plugin/)


### PR DESCRIPTION
Hi, thanks for creating this nice package!

[Stylelint 14.10.0](https://github.com/stylelint/stylelint/releases/tag/14.10.0) has supported loading a custom formatter from a package. So, we can use the `--custom-formater` option more easily without `node_modules/`.

Please see https://github.com/stylelint/stylelint/pull/6228 for details.
